### PR TITLE
Bump minimal Puppet version to 6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
Puppet 5 has reached EOL and it depends on an even more EOL Ruby.